### PR TITLE
JIT updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,6 @@ Most recent change on the bottom.
 ### Fixed
 - Edges outside the cutoff but within the skin are no longer processed by the model
 - `allow_tf32` and `_jit_bailout_depth` are now respected
+- Hack to allow freezing on demand for PyTorch < 1.10
 
 ## [0.1.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Most recent change on the bottom.
+
+## [Unreleased]
+
+### Changed
+- The mapping from LAMMPS to NequIP types is now explicitly provided
+
+### Fixed
+- Edges outside the cutoff but within the skin are no longer processed by the model
+- `allow_tf32` and `_jit_bailout_depth` are now respected
+
+## [0.1.0]

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ This pair style allows you to use NequIP models in LAMMPS simulations.
 
 ```
 pair_style	nequip
-pair_coeff	* * deployed.pth <element 1> <element 2> ...
+pair_coeff	* * deployed.pth <type name 1> <type name 2> ...
 ```
 where `deployed.pth` is the filename of your trained model.
 
-The number of elements after the model path should be exactly the same as the number of atoms in the lammps configuration (not the NequIP model!). 
-The element string should be consistent with the keys specified in the NequIP training yaml, such as the keys in `chemical_symbol_to_type` or the values in `type_names`.
+The names after the model path indicate, in order, the names of the NequIP model's atom types to use for LAMMPS atom types 1, 2, and so on. The number of names given must be equal to the number of atom types in the lammps configuration (not the NequIP model!). 
+The element string should be consistent with the names specified in the NequIP training YAML in `chemical_symbol_to_type` or `type_names`.
 
 ## Building LAMMPS with this pair style
 

--- a/pair_nequip.cpp
+++ b/pair_nequip.cpp
@@ -211,7 +211,7 @@ void PairNEQUIP::coeff(int narg, char **arg) {
   // Set whether to allow TF32:
   bool allow_tf32;
   if (metadata["allow_tf32"].empty()) {
-    // Better safe then sorry
+    // Better safe than sorry
     allow_tf32 = false;
   } else {
     // It gets saved as an int 0/1

--- a/pair_nequip.cpp
+++ b/pair_nequip.cpp
@@ -149,6 +149,11 @@ void PairNEQUIP::coeff(int narg, char **arg) {
   };
   model = torch::jit::load(std::string(arg[2]), device, metadata);
 
+  // Check if model is a NequIP model
+  if (metadata["nequip_version"].empty()) {
+    error->all(FLERR, "The indicated TorchScript file does not appear to be a deployed NequIP model; did you forget to run `nequip-deploy`?");
+  }
+
   std::cout << "Information from model: " << metadata.size() << " key-value pairs\n";
   for( const auto& n : metadata ) {
     std::cout << "Key:[" << n.first << "] Value:[" << n.second << "]\n";

--- a/pair_nequip.cpp
+++ b/pair_nequip.cpp
@@ -178,6 +178,14 @@ void PairNEQUIP::coeff(int narg, char **arg) {
   at::globalContext().setAllowTF32CuBLAS(allow_tf32);
   at::globalContext().setAllowTF32CuDNN(allow_tf32);
 
+  // If the model is not already frozen, we should freeze it:
+  if (model.parameters().size() > 0) {
+    std::cout << "Freezing TorchScript model...\n";
+    // It still has parameters, so it's unfrozen.
+    // This isn't a perfect check, but should be correct for all real models.
+    model = torch::jit::freeze(model);
+  }
+
   std::cout << "Information from model: " << metadata.size() << " key-value pairs\n";
   for( const auto& n : metadata ) {
     std::cout << "Key:[" << n.first << "] Value:[" << n.second << "]\n";


### PR DESCRIPTION
- Respect TF32 flag
- Always set JIT bailout depth to avoid long compile warmup
- Check for not a nequip model
- Freeze on load